### PR TITLE
Fixed typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
 					</div>
 					<div class="photoshop">
 						<img class="skill-img" src="images/icons/photoshop.png" width="100" alt="Adobe Photoshop">
-						<p>Windows</p>
+						<p>Photoshop</p>
 					</div>
 					<div class="git">
 						<img class="skill-img" src="images/icons/git.png" width="100" alt="Git">


### PR DESCRIPTION
You shared your website on Wes Bos' page. It looks very nice, but I noticed you had a typo where you have the Photoshop logo but it says "Windows" underneath.